### PR TITLE
Support for setting and sending shared secret

### DIFF
--- a/lib/itunes.rb
+++ b/lib/itunes.rb
@@ -28,4 +28,12 @@ module Itunes
   end
   self.sandbox = false
 
+  def self.shared_secret
+    @@shared_secret
+  end
+  def self.shared_secret=(shared_secret)
+    @@shared_secret = shared_secret
+  end
+  self.shared_secret = nil
+
 end

--- a/lib/itunes/receipt.rb
+++ b/lib/itunes/receipt.rb
@@ -45,9 +45,11 @@ module Itunes
     end
 
     def self.verify!(receipt_data)
+      request_data = {:'receipt-data' => receipt_data}
+      request_data.merge!(:password => Itunes.shared_secret) if Itunes.shared_secret
       response = RestClient.post(
         Itunes.endpoint,
-        {:'receipt-data' => receipt_data}.to_json
+        request_data.to_json
       )
       response = JSON.parse(response).with_indifferent_access
       case response[:status]

--- a/spec/itunes/receipt_spec.rb
+++ b/spec/itunes/receipt_spec.rb
@@ -11,6 +11,24 @@ describe Itunes::Receipt do
       end
     end
 
+    it 'should not pass along shared secret if not set' do
+      fake_json(:invalid)
+      Itunes.shared_secret = nil
+      RestClient.should_receive(:post).with(Itunes.endpoint, {:'receipt-data' => 'receipt-data'}.to_json).and_return("{}")
+      expect do
+        Itunes::Receipt.verify! 'receipt-data'
+      end.to raise_error Itunes::Receipt::VerificationFailed
+    end
+
+    it 'should pass along shared secret if set' do
+      fake_json(:invalid)
+      Itunes.shared_secret = 'hey'
+      RestClient.should_receive(:post).with(Itunes.endpoint, {:'receipt-data' => 'receipt-data', :password => 'hey'}.to_json).and_return("{}")
+      expect do
+        Itunes::Receipt.verify! 'receipt-data'
+      end.to raise_error Itunes::Receipt::VerificationFailed
+    end
+
     context 'when invalid' do
       before do
         fake_json :invalid

--- a/spec/itunes_spec.rb
+++ b/spec/itunes_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Itunes do
+
+  describe 'the module' do
+    before do
+      Itunes.shared_secret = nil
+    end
+
+    context 'sandbox' do
+      it 'should be production by default' do
+        Itunes.sandbox?.should be_false
+      end
+
+      it 'should be settable' do
+        Itunes.sandbox!
+        Itunes.sandbox?.should be_true
+      end
+    end
+
+    context 'shared_secret' do
+      it 'should allow setting' do
+        Itunes.shared_secret.should be_nil
+        Itunes.shared_secret = 'hey'
+        Itunes.shared_secret.should == 'hey'
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Sorry, dorky. one more necessary change to make autorenew subscriptions work. apple needs a shared secret code for these: http://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/StoreKitGuide/RenewableSubscriptions/RenewableSubscriptions.html#//apple_ref/doc/uid/TP40008267-CH4-SW2

I'll bet there will be one or two more changes in the coming days, if i'm being pessimistic.
