### PR TITLE
Retrun a boolean instead of a string

### DIFF
--- a/lib/itunes/receipt.rb
+++ b/lib/itunes/receipt.rb
@@ -65,7 +65,7 @@ module Itunes
         receipt_attributes[:in_app].map { |ia| self.class.new(:receipt => ia) }
       end
       @is_trial_period = if receipt_attributes[:is_trial_period]
-        receipt_attributes[:is_trial_period]
+        receipt_attributes[:is_trial_period] == "true"
       end
       @itunes_env = attributes[:itunes_env] || Itunes.itunes_env
       @latest = case attributes[:latest_receipt_info]


### PR DESCRIPTION
Currently `receipt.is_trial_period` returned a string instead of a boolean. I think the class should handle this.
